### PR TITLE
Add missing SQL users/passwords and security keys.

### DIFF
--- a/XP/install/install-settings.json
+++ b/XP/install/install-settings.json
@@ -24,13 +24,35 @@
             "habitatHomeSslCertificateName":"@@site.habitatHomeSslCertificateName@@",
             "addSiteBindingWithSSLPath":"@@site.addSiteBindingWithSSLPath@@"
         },
-        
         "sql": {
             "server": "@@sql.server@@",
             "adminUser": "@@sql.adminUser@@",
             "adminPassword": "@@sql.adminPassword@@",
+            "coreUser": "@@sql.coreUser@@",
+            "corePassword": "@@sql.corePassword@@",
+            "masterUser": "@@sql.masterUser@@",
+            "masterPassword": "@@sql.masterPassword@@",
+            "webUser": "@@sql.webUser@@",
+            "webPassword": "@@sql.webPassword@@",
+            "collectionUser": "@@sql.collectionUser@@",
+            "collectionPassword": "@@sql.collectionPassword@@",
+            "reportingUser": "@@sql.reportingUser@@",
+            "reportingPassword": "@@sql.reportingPassword@@",
+            "processingPoolsUser": "@@sql.processingPoolsUser@@",
+            "processingPoolsPassword": "@@sql.processingPoolsPassword@@",
+            "processingTasksUser": "@@sql.processingTasksUser@@",
+            "processingTasksPassword": "@@sql.processingTasksPassword@@",
+            "referenceDataUser": "@@sql.referenceDataUser@@",
+            "referenceDataPassword": "@@sql.referenceDataPassword@@",
+            "marketingAutomationUser": "@@sql.marketingAutomationUser@@",
+            "marketingAutomationPassword": "@@sql.marketingAutomationPassword@@",
+            "formsUser": "@@sql.formsUser@@",
+            "formsPassword": "@@sql.formsPassword@@",
+            "exmMasterUser": "@@sql.exmMasterUser@@",
+            "exmMasterPassword": "@@sql.exmMasterPassword@@",
+            "messagingUser": "@@sql.messagingUser@@",
+            "messagingPassword": "@@sql.messagingPassword@@",
             "minimumVersion":"@@sql.minimumVersion@@"
-
         },
         "xConnect": {
             "configurationPath": "@@xConnect.configurationPath@@",
@@ -39,23 +61,23 @@
             "packagePath": "@@xConnect.packagePath@@",
             "siteName": "@@xConnect.siteName@@",
             "certificateName": "@@xConnect.certificate@@",
-            "siteRoot": "@@xConnect.siteRoot@@",
-            "sqlCollectionUser": "@@xConnect.sqlCollectionUser@@",
-            "sqlCollectionPassword": "@@xConnect.sqlConnectionPassword@@"
+            "siteRoot": "@@xConnect.siteRoot@@"
         },
         "sitecore": {
             "solrConfigurationPath": "@@sitecore.solrConfigurationPath@@",
             "configurationPath": "@@sitecore.configurationPath@@",
             "sslConfigurationPath": "@@sitecore.sslConfigurationPath@@",
             "packagePath": "@@sitecore.packagePath@@",
-            "siteRoot": "@@sitecore.siteRoot@@"
-
+            "siteRoot": "@@sitecore.siteRoot@@",
+            "adminPassword": "@@sitecore.adminPassword@@",
+            "exmCryptographicKey": "@@sitecore.exmCryptographicKey@@",
+            "exmAuthenticationKey": "@@sitecore.exmAuthenticationKey@@",
+            "telerikEncryptionKey": "@@sitecore.telerikEncryptionKey@@"
         },
         "solr": {
             "url": "@@solr.url@@",
             "root": "@@solr.root@@",
             "serviceName": "@@solr.serviceName@@"
-
         }
     },
     "modules":[
@@ -108,7 +130,4 @@
             "install":"@@modules.defDynamicsConnectInstall@@"
         }
     ]
-
-
-
 }

--- a/XP/install/install-xp0.ps1
+++ b/XP/install/install-xp0.ps1
@@ -116,6 +116,7 @@ function Confirm-Prerequisites {
     #Enable Contained Databases
     Write-Host "Enable contained databases" -ForegroundColor Green
     try {
+        # This command can set the location to SQLSERVER:\
         Invoke-Sqlcmd -ServerInstance $sql.server `
             -Username $sql.adminUser `
             -Password $sql.adminPassword `
@@ -125,6 +126,9 @@ function Confirm-Prerequisites {
         write-host "Set Enable contained databases failed" -ForegroundColor Red
         throw
     }
+
+    # Reset location to script root
+    Set-Location $PSScriptRoot
 
     # Verify Solr
     Write-Host "Verifying Solr connection" -ForegroundColor Green
@@ -310,38 +314,44 @@ function Install-XConnect {
         write-host "XConnect Certificate Creation Failed" -ForegroundColor Red
         throw
     }
-    
+
     #Install xConnect
     try {
         $params = @{
-            Path                  = $xConnect.ConfigurationPath 
-            Package               = $xConnect.PackagePath 
-            LicenseFile           = $assets.licenseFilePath 
-            SiteName              = $xConnect.siteName 
-            XConnectCert          = $xConnect.certificateName 
-            SqlDbPrefix           = $site.prefix 
-            SolrCorePrefix        = $site.prefix 
-            SqlAdminUser          = $sql.adminUser 
-            SqlAdminPassword      = $sql.adminPassword 
-            SqlServer             = $sql.server 
-            SqlCollectionUser     = $xConnect.sqlCollectionUser 
-            SqlCollectionPassword = $xConnect.sqlCollectionPassword 
-            SolrUrl               = $solr.url 
-            WebRoot               = $site.webRoot
+            Path                           = $xConnect.ConfigurationPath
+            Package                        = $xConnect.PackagePath
+            LicenseFile                    = $assets.licenseFilePath
+            SiteName                       = $xConnect.siteName
+            XConnectCert                   = $xConnect.certificateName
+            SqlDbPrefix                    = $site.prefix
+            SolrCorePrefix                 = $site.prefix
+            SqlAdminUser                   = $sql.adminUser
+            SqlAdminPassword               = $sql.adminPassword
+            SqlServer                      = $sql.server
+            SqlCollectionUser              = $sql.collectionUser
+            SqlCollectionPassword          = $sql.collectionPassword
+            SqlProcessingPoolsUser         = $sql.processingPoolsUser
+            SqlProcessingPoolsPassword     = $sql.processingPoolsPassword
+            SqlReferenceDataUser           = $sql.referenceDataUser
+            SqlReferenceDataPassword       = $sql.referenceDataPassword
+            SqlMarketingAutomationUser     = $sql.marketingAutomationUser
+            SqlMarketingAutomationPassword = $sql.marketingAutomationPassword
+            SqlMessagingUser               = $sql.messagingUser
+            SqlMessagingPassword           = $sql.messagingPassword
+            SolrUrl                        = $solr.url
+            WebRoot                        = $site.webRoot
         }
         Install-SitecoreConfiguration @params -WorkingDirectory $(Join-Path $PWD "logs")
-        
     }
     catch {
         write-host "XConnect Setup Failed" -ForegroundColor Red
         throw
     }
-                             
 
     #Set rights on the xDB connection database
     Write-Host "Setting Collection User rights" -ForegroundColor Green
     try {
-        $sqlVariables = "DatabasePrefix = $($site.prefix)", "UserName = $($xConnect.sqlCollectionUser)", "Password = $($xConnect.sqlCollectionPassword)"
+        $sqlVariables = "DatabasePrefix = $($site.prefix)", "UserName = $($sql.collectionUser)", "Password = $($sql.collectionPassword)"
         Invoke-Sqlcmd -ServerInstance $sql.server `
             -Username $sql.adminUser `
             -Password $sql.adminPassword `
@@ -359,10 +369,10 @@ function Install-Sitecore {
     try {
         #Install Sitecore Solr
         $params = @{
-            Path        = $sitecore.solrConfigurationPath 
-            SolrUrl     = $solr.url 
-            SolrRoot    = $solr.root 
-            SolrService = $solr.serviceName 
+            Path        = $sitecore.solrConfigurationPath
+            SolrUrl     = $solr.url
+            SolrRoot    = $solr.root
+            SolrService = $solr.serviceName
             CorePrefix  = $site.prefix
         }
         Install-SitecoreConfiguration  @params -WorkingDirectory $(Join-Path $PWD "logs")
@@ -376,30 +386,55 @@ function Install-Sitecore {
         #Install Sitecore
         $params = @{
             Path                                 = $sitecore.configurationPath
-            Package                              = $sitecore.packagePath 
-            LicenseFile                          = $assets.licenseFilePath 
-            SiteName                             = $site.hostName 
-            XConnectCert                         = $xConnect.certificateName 
-            SqlDbPrefix                          = $site.prefix 
-            SolrCorePrefix                       = $site.prefix 
-            SqlAdminUser                         = $sql.adminUser 
-            SqlAdminPassword                     = $sql.adminPassword 
-            SqlServer                            = $sql.server 
+            Package                              = $sitecore.packagePath
+            LicenseFile                          = $assets.licenseFilePath
+            SiteName                             = $site.hostName
+            XConnectCert                         = $xConnect.certificateName
+            SqlDbPrefix                          = $site.prefix
+            SolrCorePrefix                       = $site.prefix
+            SitecoreAdminPassword                = $sitecore.adminPassword
+            SqlAdminUser                         = $sql.adminUser
+            SqlAdminPassword                     = $sql.adminPassword
+            SqlCoreUser                          = $sql.coreUser
+            SqlCorePassword                      = $sql.corePassword
+            SqlMasterUser                        = $sql.masterUser
+            SqlMasterPassword                    = $sql.masterPassword
+            SqlWebUser                           = $sql.webUser
+            SqlWebPassword                       = $sql.webPassword
+            SqlReportingUser                     = $sql.reportingUser
+            SqlReportingPassword                 = $sql.reportingPassword
+            SqlProcessingPoolsUser               = $sql.processingPoolsUser
+            SqlProcessingPoolsPassword           = $sql.processingPoolsPassword
+            SqlProcessingTasksUser               = $sql.processingTasksUser
+            SqlProcessingTasksPassword           = $sql.processingTasksPassword
+            SqlReferenceDataUser                 = $sql.referenceDataUser
+            SqlReferenceDataPassword             = $sql.referenceDataPassword
+            SqlMarketingAutomationUser           = $sql.marketingAutomationUser
+            SqlMarketingAutomationPassword       = $sql.marketingAutomationPassword
+            SqlFormsUser                         = $sql.formsUser
+            SqlFormsPassword                     = $sql.formsPassword
+            SqlExmMasterUser                     = $sql.exmMasterUser
+            SqlExmMasterPassword                 = $sql.exmMasterPassword
+            SqlMessagingUser                     = $sql.messagingUser
+            SqlMessagingPassword                 = $sql.messagingPassword
+            SqlServer                            = $sql.server
+            EXMCryptographicKey                  = $sitecore.exmCryptographicKey
+            EXMAuthenticationKey                 = $sitecore.exmAuthenticationKey
             SolrUrl                              = $solr.url
-            XConnectCollectionService            = "https://$($xConnect.siteName)" 
-            XConnectReferenceDataService         = "https://$($xConnect.siteName)" 
-            MarketingAutomationOperationsService = "https://$($xConnect.siteName)" 
+            XConnectCollectionService            = "https://$($xConnect.siteName)"
+            XConnectReferenceDataService         = "https://$($xConnect.siteName)"
+            MarketingAutomationOperationsService = "https://$($xConnect.siteName)"
             MarketingAutomationReportingService  = "https://$($xConnect.siteName)"
+            TelerikEncryptionKey                 = $sitecore.telerikEncryptionKey
             WebRoot                              = $site.webRoot
         }
         Install-SitecoreConfiguration  @params -WorkingDirectory $(Join-Path $PWD "logs")
-            
     }
     catch {
         write-host "Sitecore Setup Failed" -ForegroundColor Red
         throw
     }
-    }
+}
 
 function Enable-InstallationImprovements {
     try {
@@ -432,6 +467,8 @@ function Disable-InstallationImprovements {
 }
 
 function Copy-Tools {
+    #Copy InstallPackage.aspx to webroot
+
     if (!(Test-Path $assets.installPackagePath)) {
         throw "$($assets.installPackagePath) not found"
     }
@@ -489,8 +526,6 @@ Function Set-ModulesPath {
 }
 
 function Install-OptionalModules {
-    #Copy InstallPackage.aspx to webroot
-    
     $packageDestination = Join-Path $sitecore.siteRoot "\temp\Packages"
     foreach ($module in $modules | Where-Object {$_.install -eq $true}) {
         Write-Host "Copying $($module.name) to the $packageDestination"

--- a/XP/install/set-installation-defaults.ps1
+++ b/XP/install/set-installation-defaults.ps1
@@ -41,32 +41,55 @@ $sql = $json.settings.sql
 $sql.server = "."
 $sql.adminUser = "sa"
 $sql.adminPassword = "12345"
+$sql.coreUser = $site.prefix + "coreuser"
+$sql.corePassword = "Test12345"
+$sql.masterUser = $site.prefix + "masteruser"
+$sql.masterPassword = "Test12345"
+$sql.webUser = $site.prefix + "webuser"
+$sql.webPassword = "Test12345"
+$sql.collectionUser = $site.prefix + "collectionuser"
+$sql.collectionPassword = "Test12345"
+$sql.reportingUser = $site.prefix + "reportinguser"
+$sql.reportingPassword = "Test12345"
+$sql.processingPoolsUser = $site.prefix + "poolsuser"
+$sql.processingPoolsPassword = "Test12345"
+$sql.processingTasksUser = $site.prefix + "tasksuser"
+$sql.processingTasksPassword = "Test12345"
+$sql.referenceDataUser = $site.prefix + "referencedatauser"
+$sql.referenceDataPassword = "Test12345"
+$sql.marketingAutomationUser = $site.prefix + "marketingautomationuser"
+$sql.marketingAutomationPassword = "Test12345"
+$sql.formsUser = $site.prefix + "formsuser"
+$sql.formsPassword = "Test12345"
+$sql.exmMasterUser = $site.prefix + "exmmasteruser"
+$sql.exmMasterPassword = "Test12345"
+$sql.messagingUser = $site.prefix + "messaginguser"
+$sql.messagingPassword = "Test12345"
 $sql.minimumVersion="13.0.4001"
 
 Write-Host "Setting default 'xConnect' parameters"
 # XConnect Parameters
 $xConnect = $json.settings.xConnect
-
-$xConnect.ConfigurationPath = (Get-ChildItem $pwd -filter "xconnect-xp0.json" -Recurse).FullName 
+$xConnect.ConfigurationPath = (Get-ChildItem $pwd -filter "xconnect-xp0.json" -Recurse).FullName
 $xConnect.certificateConfigurationPath = (Get-ChildItem $pwd -filter "xconnect-createcert.json" -Recurse).FullName
-$xConnect.solrConfigurationPath = (Get-ChildItem $pwd -filter "xconnect-solr.json" -Recurse).FullName 
+$xConnect.solrConfigurationPath = (Get-ChildItem $pwd -filter "xconnect-solr.json" -Recurse).FullName
 $xConnect.packagePath = Join-Path $assets.root $("Sitecore " + $assets.sitecoreVersion + " (OnPrem)_xp0xconnect.scwdp.zip")
 $xConnect.siteName = $site.prefix + "_xconnect." + $site.suffix
 $xConnect.certificateName = [string]::Join(".", @($site.prefix, $site.suffix, "xConnect.Client"))
 $xConnect.siteRoot = Join-Path $site.webRoot -ChildPath $xConnect.siteName
-$xConnect.sqlCollectionUser = $site.prefix + "collectionuser"
-$xConnect.sqlCollectionPassword = "Test12345"
 
 Write-Host "Setting default 'Sitecore' parameters"
-
 # Sitecore Parameters
 $sitecore = $json.settings.sitecore
-
-$sitecore.solrConfigurationPath =  (Get-ChildItem $pwd -filter "sitecore-solr.json" -Recurse).FullName 
-$sitecore.configurationPath = (Get-ChildItem $pwd -filter "sitecore-xp0.json" -Recurse).FullName 
+$sitecore.solrConfigurationPath =  (Get-ChildItem $pwd -filter "sitecore-solr.json" -Recurse).FullName
+$sitecore.configurationPath = (Get-ChildItem $pwd -filter "sitecore-xp0.json" -Recurse).FullName
 $sitecore.sslConfigurationPath = "$PSScriptRoot\certificates\sitecore-ssl.json"
 $sitecore.packagePath = Join-Path $assets.root $("Sitecore " + $assets.sitecoreVersion +" (OnPrem)_single.scwdp.zip")
 $sitecore.siteRoot = Join-Path $site.webRoot -ChildPath $site.hostName
+$sitecore.adminPassword = "b"
+$sitecore.exmCryptographicKey = "0x0000000000000000000000000000000000000000000000000000000000000000"
+$sitecore.exmAuthenticationKey = "0x0000000000000000000000000000000000000000000000000000000000000000"
+$sitecore.telerikEncryptionKey = "PutYourCustomEncryptionKeyHereFrom32To256CharactersLong"
 
 Write-Host "Setting default 'Solr' parameters"
 # Solr Parameters
@@ -76,6 +99,7 @@ $solr.root = "c:\solr"
 $solr.serviceName = "Solr"
 
 Write-Host "Setting default 'modules' parameters"
+# Modules
 $modules = $json.modules
 
 $spe = $modules | Where-Object { $_.id -eq "spe"}

--- a/XP/install/set-installation-overrides.ps1.example
+++ b/XP/install/set-installation-overrides.ps1.example
@@ -7,17 +7,14 @@ Param(
 
 # You can remove any items that you do not need to override. Keep in mind the dependency on other settings when removing items.
 # For example, $assets is used in various sections.
-  
+
 Write-Host "Setting Local Overrides in $configurationFile"
 
 $json = Get-Content -Raw $configurationFile |  ConvertFrom-Json
 
 # Assets and prerequisites
-
-$assets = $json.assets 
+$assets = $json.assets
 $assets.licenseFilePath = Join-Path $assets.root "license.xml"
-$json.assets = $assets
-
 
 # Settings
 
@@ -28,11 +25,14 @@ $site.suffix = "dev.local"
 $site.webroot = "C:\inetpub\wwwroot"
 $site.hostName = $json.settings.site.prefix + "." + $json.settings.site.suffix
 $site.habitatHomeSslCertificateName = $site.hostName
-$json.settings.site = $site
 
+# Sitecore Parameters
 $sitecore = $json.settings.sitecore
 $sitecore.siteRoot = Join-Path $site.webRoot -ChildPath $site.hostName
-$json.settings.sitecore = $sitecore
+$sitecore.adminPassword = "b"
+$sitecore.exmCryptographicKey = "0x0000000000000000000000000000000000000000000000000000000000000000"
+$sitecore.exmAuthenticationKey = "0x0000000000000000000000000000000000000000000000000000000000000000"
+$sitecore.telerikEncryptionKey = "PutYourCustomEncryptionKeyHereFrom32To256CharactersLong"
 
 # Solr Parameters
 $solr = $json.settings.solr
@@ -40,24 +40,39 @@ $solr.url = "https://localhost:8983/solr"
 $solr.root = "c:\solr\solr-6.6.2"
 $solr.serviceName = "Solr-6.6.2"
 
-
-$sql = $json.settings.sql
 # SQL Settings
 $sql.server = "."
 $sql.adminUser = "sa"
 $sql.adminPassword = "12345"
-
-$json.settings.sql = $sql
+$sql.coreUser = $site.prefix + "coreuser"
+$sql.corePassword = "Test12345"
+$sql.masterUser = $site.prefix + "masteruser"
+$sql.masterPassword = "Test12345"
+$sql.webUser = $site.prefix + "webuser"
+$sql.webPassword = "Test12345"
+$sql.collectionUser = $site.prefix + "collectionuser"
+$sql.collectionPassword = "Test12345"
+$sql.reportingUser = $site.prefix + "reportinguser"
+$sql.reportingPassword = "Test12345"
+$sql.processingPoolsUser = $site.prefix + "poolsuser"
+$sql.processingPoolsPassword = "Test12345"
+$sql.processingTasksUser = $site.prefix + "tasksuser"
+$sql.processingTasksPassword = "Test12345"
+$sql.referenceDataUser = $site.prefix + "referencedatauser"
+$sql.referenceDataPassword = "Test12345"
+$sql.marketingAutomationUser = $site.prefix + "marketingautomationuser"
+$sql.marketingAutomationPassword = "Test12345"
+$sql.formsUser = $site.prefix + "formsuser"
+$sql.formsPassword = "Test12345"
+$sql.exmMasterUser = $site.prefix + "exmmasteruser"
+$sql.exmMasterPassword = "Test12345"
+$sql.messagingUser = $site.prefix + "messaginguser"
+$sql.messagingPassword = "Test12345"
 
 # XConnect Parameters
 $xConnect = $json.settings.xConnect
-
 $xConnect.siteName = $site.prefix + "_xconnect." + $site.suffix
 $xConnect.certificateName = [string]::Join(".", @($site.prefix, $site.suffix, "xConnect.Client"))
 $xConnect.siteRoot = Join-Path $site.webRoot -ChildPath $xConnect.siteName
-$xConnect.sqlCollectionUser = $site.prefix + "collectionuser"
-$xConnect.sqlCollectionPassword = "Test12345"
-
-$json.settings.xConnect = $xConnect
 
 Set-Content $configurationFile  (ConvertTo-Json -InputObject $json -Depth 3)

--- a/XP/install/uninstall-xp0.ps1
+++ b/XP/install/uninstall-xp0.ps1
@@ -114,7 +114,7 @@ Get-WmiObject win32_service  -Filter "name like '$($solr.serviceName)'" | Start-
 Remove-SitecoreCertificate $site.hostName
 
 # Drop the SQL Collectionuser login
-Remove-SitecoreDatabaseLogin -Server $database, -Name $($xConnect.sqlCollectionUser)
+Remove-SitecoreDatabaseLogin -Server $database -Name $($sql.collectionUser)
 
 # Remove App Pool membership 
 


### PR DESCRIPTION
- Add missing SQL users/passwords in configuration for systems where the password policy is more strict.
- Move SQL collection user and password from xConnect to SQL configuration.
- Add configurable Sitecore password and various encryption keys.
- Fix a bug where the shell location switched to `SQLSERVER:/` when enabling contained databases.
- Fix a bug where the collectionuser was not dropped from SQL at uninstall due to a comma between arguments.
- Remove not needed variable assignments in `XP/install/set-installation-overrides.ps1.example`.