### PR TITLE
Enhancements for Solr installation

### DIFF
--- a/XP/install/README.md
+++ b/XP/install/README.md
@@ -9,19 +9,29 @@ Solr can be installed with a script if you do not already have it.
 Still in an elevated PowerShell session:
 
 - Browse to the solr folder
-	```
+
+  ```powershell
   Set-Location Sitecore.Habitathome.Utilities\XP\Install\solr
-	```
+  ```
 
 - Review the `install-solr.ps1` script to ensure the Java and Solr versions are correct
 
 - Install Solr
-	```
-	.\install-solr.ps1 -JREVersion <version of JRE you have installed ie: 1.8.0_181>
-	```
 
-> **Known Issue**: error finding keytool. For now, exit and re-open Powershell and run the script again
+  ```powershell
+  .\install-solr.ps1
+  ```
+
 > Once setup is complete, the installer should load the solr 'home' page
+
+#### To Uninstall Solr
+
+- Review the `remove-solr.ps1` script to ensure the Solr versions and its data folder are correct.
+- Uninstall Solr
+
+  ```powershell
+  .\remove-solr.ps1
+  ```
 
 ### Prepare to install XP
 

--- a/XP/install/Solr/helper.psm1
+++ b/XP/install/Solr/helper.psm1
@@ -1,0 +1,105 @@
+Function Get-JavaVersions() {
+    $versions = '', 'Wow6432Node\' |
+        ForEach-Object {Get-ItemProperty -Path HKLM:\SOFTWARE\$($_)Microsoft\Windows\CurrentVersion\Uninstall\* |
+            Where-Object {($_.DisplayName -like '*Java *') -and (-not $_.SystemComponent)} |
+            Select-Object DisplayName, DisplayVersion, InstallLocation, @{n = 'Architecture'; e = {If ($_.PSParentPath -like '*Wow6432Node*') {'x86'} Else {'x64'}}}}
+    
+    return $versions
+}
+Function Get-JavaInstallationPath
+{
+    param (
+        [version] $toVersion
+    )
+    $versions_ = Get-JavaVersions
+    $foundRightVersion = $false
+    $JavaInstallPath = ""
+    foreach ($version_ in $versions_) {
+        try {
+            $version = New-Object System.Version($version_.DisplayVersion)
+        }
+        catch {
+            continue
+        }
+        
+        if ($version.CompareTo($toVersion) -ge 0) {
+            $foundRightVersion = $true
+            $JavaInstallPath = $version_.InstallLocation
+            break;
+        }
+    }
+
+    if (-not $foundRightVersion) {
+        throw "Invalid Java version. Expected $JavaMinVersionRequired or above."
+    }
+    return $JavaInstallPath
+}
+
+Function Find-UpdateJAVAHOME
+{
+    param (
+        [Version] $JavaMinVersionRequired
+    )
+    $JREPath = Get-JavaInstallationPath($JavaMinVersionRequired)
+    
+    $jreVal_ = [Environment]::GetEnvironmentVariable("JAVA_HOME", [EnvironmentVariableTarget]::Machine)
+    if($jreVal_ -ne $JREPath)
+    {
+        Write-Host "Setting JAVA_HOME environment variable"
+        [Environment]::SetEnvironmentVariable("JAVA_HOME", $JREPath, [EnvironmentVariableTarget]::Machine)
+        
+        # Fixed known issue: error finding keytool
+        $jreVal_ = $JREPath
+    }
+
+    return $jreVal_
+}
+
+Function Get-JavaKeytool
+{
+    param (
+        [string] $JavaMinVersionRequired = "8.0.1510"
+    )
+
+    $RequiredVersion = New-Object System.Version($JavaMinVersionRequired)
+    try {
+        $jreVal = Find-UpdateJAVAHOME -JavaMinVersionRequired $RequiredVersion
+        
+        $path = $jreVal + '\bin\keytool.exe'
+        
+        if (Test-Path $path) {
+            $keytool_ = (Get-Command $path).Source
+        }
+    } catch {
+        $keytool_ = Read-Host "keytool.exe not on path. Enter path to keytool (found in JRE bin folder)"
+    }
+
+    if([string]::IsNullOrEmpty($keytool_) -or -not (Test-Path $keytool_)) {
+        throw "Keytool path was invalid."
+    }
+
+    return $keytool_
+}
+
+function downloadAndUnzipIfRequired
+{
+    Param(
+        [string]$toolName,
+        [string]$toolFolder,
+        [string]$toolZip,
+        [string]$toolSourceFile,
+        [string]$installRoot
+    )
+
+    if(!(Test-Path -Path $toolFolder))
+    {
+        if(!(Test-Path -Path $toolZip))
+        {
+            Write-Host "Downloading $toolName..."
+            Start-BitsTransfer -Source $toolSourceFile -Destination $toolZip
+        }
+
+        Write-Host "Extracting $toolName to $toolFolder..."
+        Expand-Archive $toolZip -DestinationPath $installRoot
+    }
+}

--- a/XP/install/Solr/remove-solr.ps1
+++ b/XP/install/Solr/remove-solr.ps1
@@ -1,0 +1,70 @@
+Param(
+    [string]$solrVersion = "6.6.2",
+    [string]$installFolder = "c:\solr",
+    [string]$nssmVersion = "2.24",
+    [string]$keystoreSecret = "secret",
+	[string]$KeystoreFile = 'solr-ssl.keystore.jks'
+)
+
+
+$solrName = "solr-$solrVersion"
+$solrRoot = "$installFolder\$solrName"
+$nssmRoot = "$installFolder\nssm-$nssmVersion"
+$nssmPackage = "http://nssm.cc/release/nssm-$nssmVersion.zip"
+$downloadFolder =(Resolve-Path "..\assets")
+
+$JavaMinVersionRequired = "8.0.1510"
+
+$ErrorActionPreference = 'Stop'
+
+if (Get-Module("helper")) {
+   Remove-Module "helper"
+}
+Import-Module "$PSScriptRoot\helper.psm1"  
+
+# download & extract the nssm archive to the right folder
+$nssmZip = "$downloadFolder\nssm-$nssmVersion.zip"
+downloadAndUnzipIfRequired "NSSM" $nssmRoot $nssmZip $nssmPackage $installFolder
+
+Write-Host "Removing Solr service: $($solrName)" -ForegroundColor Green
+$svc = Get-Service "$solrName" -ErrorAction SilentlyContinue
+if($svc)
+{
+    $nssmTool = "$nssmRoot\win64\nssm.exe"
+    if ($svc.Status -eq "Running")
+    {
+        &"$nssmTool" stop "$solrName"
+    }
+    &"$nssmTool" remove "$solrName" confirm
+}
+
+
+if((Test-Path $KeystoreFile)) {
+    Write-Host "Removing JKS file: $($KeystoreFile)" -ForegroundColor Green
+    
+    # Ensure Java environment variable
+    try {
+        $keytool = (Get-Command 'keytool.exe').Source
+    } catch {
+        $keytool = Get-JavaKeytool -JavaMinVersionRequired $JavaMinVersionRequired
+    } 
+
+    & $keytool -delete -alias "solr-ssl" -storetype JKS -keystore $KeystoreFile -storepass $keystoreSecret
+
+    Remove-Item $KeystoreFile
+    
+    $P12Path = [IO.Path]::ChangeExtension($KeystoreFile, 'p12')
+    Write-Host "Removing P12 file: $($P12Path)" -ForegroundColor Green
+    if((Test-Path $P12Path)) {
+        Remove-Item $P12Path
+    }
+}
+
+
+Write-Host "Removing Solr root folder: $($solrRoot)" -ForegroundColor Green
+If((Test-Path $solrRoot)) {
+    Remove-Item -Path $solrRoot -Force -Recurse
+} 
+
+Write-Host "Removing Solr SSL Certificate" -ForegroundColor Green
+Get-ChildItem -Path "Cert:\LocalMachine\Root" | Where-Object -Property FriendlyName -eq "solr-ssl" | Remove-Item

--- a/XP/install/install-xp0.ps1
+++ b/XP/install/install-xp0.ps1
@@ -127,45 +127,6 @@ Function Confirm-Prerequisites {
         throw "Invalid SQL version. Expected SQL 2016 SP1 ($($sql.minimumVersion)) or above."
     }
 
-    #Verify Java version
-    
-    $minVersion = New-Object System.Version($assets.jreRequiredVersion)
-    $foundVersion = $FALSE
-   
-    
-    function getJavaVersions() {
-        $versions = '', 'Wow6432Node\' |
-            ForEach-Object {Get-ItemProperty -Path HKLM:\SOFTWARE\$($_)Microsoft\Windows\CurrentVersion\Uninstall\* |
-                Where-Object {($_.DisplayName -like '*Java *') -and (-not $_.SystemComponent)} |
-                Select-Object DisplayName, DisplayVersion, @{n = 'Architecture'; e = {If ($_.PSParentPath -like '*Wow6432Node*') {'x86'} Else {'x64'}}}}
-        return $versions
-    }
-    function checkJavaversion($toVersion) {
-        $versions_ = getJavaVersions
-        foreach ($version_ in $versions_) {
-            try {
-                $version = New-Object System.Version($version_.DisplayVersion)
-                
-            }
-            catch {
-                continue
-            }
-
-            if ($version.CompareTo($toVersion) -ge 0) {
-                return $TRUE
-            }
-        }
-
-        return $false
-
-    }
-    
-    $foundVersion = checkJavaversion($minversion)
-    
-    if (-not $foundVersion) {
-        throw "Invalid Java version. Expected $minVersion or above."
-    }
-
     # Verify Web Deploy
     $webDeployPath = ([IO.Path]::Combine($env:ProgramFiles, 'iis', 'Microsoft Web Deploy V3', 'msdeploy.exe'))
     if (!(Test-Path $webDeployPath)) {


### PR DESCRIPTION
- Move the script of verifying Java version into install Solr script (since Java is required by Solr not Sitecore)
- Fixed the known issue "error finding keytool"
- Get the Java's InstallationLocation via registry => no need to pass the JREVersion param
- Script of removing Solr stuffs: service, solr's data folder, jks & p12 files and certificate