### PR TITLE
Append site.prefix after BizFx and IdentityServer

### DIFF
--- a/XC/install/assets/Resources/Configuration/Commerce/SitecoreBizFx/SitecoreBizFx.json
+++ b/XC/install/assets/Resources/Configuration/Commerce/SitecoreBizFx/SitecoreBizFx.json
@@ -35,7 +35,8 @@
     }
   },
   "Variables": {
-    "SitecoreBizFxPhysicalPath": "[joinpath(parameter('WebRoot'), concat('\\SitecoreBizFx', parameter('SitecoreBizFxPostFix')))]",
+		"SitecoreBizFxSiteName": "[concat('SitecoreBizFx_', parameter('SitecoreBizFxPostFix'))]",
+    "SitecoreBizFxPhysicalPath": "[joinpath(parameter('WebRoot'), concat('\\', variable('SitecoreBizFxSiteName')))]",
     "Root.Cert.DnsName": "[concat('DO_NOT_TRUST_', parameter('RootCertFileName'))]",
     "Root.Cert.Store": "cert:\\LocalMachine\\Root"
   },
@@ -48,7 +49,7 @@
 		"StopSite": {
 			"Type": "ManageWebsite",
 			"Params": {
-				"Name": "SitecoreBizFx",
+				"Name": "[variable('SitecoreBizFxSiteName')]",
 				"Action": "Stop",
 				"ErrorAction": "SilentlyContinue"
 			}
@@ -56,14 +57,14 @@
 		"RemoveSite": {
 			"Type": "ManageCommerceService",
 			"Params": {
-				"Name": "SitecoreBizFx",
+				"Name": "[variable('SitecoreBizFxSiteName')]",
 				"Action": "Remove-Website"
 			}
 		},
 		"StopAppPool": {
 			"Type": "ManageAppPool",
 			"Params": {
-				"Name": "SitecoreBizFx",
+				"Name": "[variable('SitecoreBizFxSiteName')]",
 				"Action": "Stop",
 				"ErrorAction": "SilentlyContinue"
 			}
@@ -71,7 +72,7 @@
 		"RemoveAppPool": {
 			"Type": "ManageCommerceService",
 			"Params": {
-				"Name": "SitecoreBizFx",
+				"Name": "[variable('SitecoreBizFxSiteName')]",
 				"Action": "Remove-WebAppPool"
 			}
 		},
@@ -105,7 +106,7 @@
 		"CreateWebAppPool": {
 			"Type": "ManageCommerceService",
 			"Params": {
-				"Name": "SitecoreBizFx",
+				"Name": "[variable('SitecoreBizFxSiteName')]",
 				"Action": "Create-WebAppPool",
 				"UserAccount": "[parameter('UserAccount')]"
 			}
@@ -113,9 +114,9 @@
 		"CreateWebsite": {
 			"Type": "ManageCommerceService",
 			"Params": {
-				"Name": "SitecoreBizFx",
+				"Name": "[variable('SitecoreBizFxSiteName')]",
 				"Action": "Create-Website",
-				"AppPoolName": "SitecoreBizFx",
+				"AppPoolName": "[variable('SitecoreBizFxSiteName')]",
 				"PhysicalPath": "[variable('SitecoreBizFxPhysicalPath')]",
 				"Port": "4200",
 				"Signer": "[GetCertificate(variable('Root.Cert.DnsName'), variable('Root.Cert.Store'))]"

--- a/XC/install/install-xc0.ps1
+++ b/XC/install/install-xc0.ps1
@@ -345,7 +345,7 @@ Function Install-Commerce {
             PublicKey  = $commerce.brainTreeAccountPublicKey
             PrivateKey = $commerce.brainTreeAccountPrivateKey
         }
-        SitecoreIdentityServerName                  = "SitecoreIdentityServer"
+        SitecoreIdentityServerName                  = $commerce.identityServerName
     }
 
     Install-SitecoreConfiguration @params -WorkingDirectory $(Join-Path $PWD "logs")

--- a/XC/install/set-installation-defaults.ps1
+++ b/XC/install/set-installation-defaults.ps1
@@ -56,7 +56,7 @@ $commerce.serviceAccountPassword = "Pu8azaCr"
 $commerce.brainTreeAccountMerchandId = ""
 $commerce.brainTreeAccountPublicKey = ""
 $commerce.brainTreeAccountPrivateKey = ""
-$commerce.identityServerName = "SitecoreIdentityServer"
+$commerce.identityServerName = "SitecoreIdentityServer_$($site.prefix)"
 
 # Site Settings
 $site = $json.settings.site

--- a/XC/install/uninstall-xcSingle.ps1
+++ b/XC/install/uninstall-xcSingle.ps1
@@ -126,10 +126,10 @@ foreach ($environment in $Environments) {
     Remove-Item ("$($site.webRoot)\{0}_backup" -f $siteName) -recurse -force -ErrorAction SilentlyContinue
 }
 $bizfxPrefix = "SitecoreBizFx"
-$bizfx = ("{0}{1}" -f $bizfxPrefix, $site.prefix)
+$bizfx = ("{0}_{1}" -f $bizfxPrefix, $site.prefix)
 Write-Host ("Deleting Website {0}" -f $bizfx)
-Remove-Website -siteName $bizfxPrefix -ErrorAction SilentlyContinue
-Remove-AppPool -appPoolName $bizfxPrefix
+Remove-Website -siteName $bizfx -ErrorAction SilentlyContinue
+Remove-AppPool -appPoolName $bizfx
 Remove-Item ("$($site.webRoot)\{0}" -f $bizfx) -recurse -force -ErrorAction SilentlyContinue
 
 Write-Host ("Deleting Website {0}" -f $commerce.identityServerName)


### PR DESCRIPTION
Append `site.prefix` after the name **BizFx** and **IdentityServer**. For instance, **SitecoreBizFx_habitathome** and **SitecoreIdentityServer_habitathome**.

It affected to the name of folder, web application and application pool.