### PR TITLE
Feature/refactoring scripts

### DIFF
--- a/XC/install/Add-BindingsToCommerceSites.ps1
+++ b/XC/install/Add-BindingsToCommerceSites.ps1
@@ -1,7 +1,7 @@
 Param(
     [string] $hostName = "my.hostname",
     [string]$CertificateName = "my.hostname",
-    [string[]]$sites = @("CommerceAuthoring_habitathome:5000", "CommerceMinions_habitathome:5010", "CommerceOps_habitathome:5015", "CommerceShops_habitathome:5020", "SitecoreBizFx:4200", "SitecoreIdentityServer:5050")
+    [string[]]$sites = @("CommerceAuthoring_habitathome:5000", "CommerceMinions_habitathome:5010", "CommerceOps_habitathome:5015", "CommerceShops_habitathome:5005", "SitecoreBizFx_habitathome:4200", "SitecoreIdentityServer_habitathome:5050")
 )
 
 Set-Location (Resolve-Path "..\..\XP\Install")

--- a/XC/install/README.md
+++ b/XC/install/README.md
@@ -38,7 +38,7 @@ Still in an elevated PowerShell session
 
 Once the above files have been downloaded, these are **_2 options_** to install the Sitecore Experience Commerce
 
-- If you plan on installing Habitat Home Demo (**Sitecore.HabitatHome.Commerce**), execute the script without parameter
+- If you plan on installing the Habitat Home Demo (**Sitecore.HabitatHome.Commerce**), execute the script without parameter
 
     ```powershell
     .\install-xc0.ps1

--- a/XC/install/README.md
+++ b/XC/install/README.md
@@ -5,26 +5,30 @@
 Still in an elevated PowerShell session
 
 - Browse to the XC installation folder
-  ```
-  Set-Location ..\..\XC\install
-  ```
+  
+    ```powershell
+    Set-Location ..\..\XC\install
+    ```
 
 - Set some predefined defaults
-  ```
-  .\set-installation-defaults.ps1
-  ```
+  
+    ```powershell
+    .\set-installation-defaults.ps1
+    ```
 
 - Create a copy of the overrides file
-  ```
-  copy set-installation-overrides.ps1.example set-installation-overrides.ps1
-  ```
+
+    ```powershell
+    copy set-installation-overrides.ps1.example set-installation-overrides.ps1
+    ```
 
 - Edit **`set-installation-overrides.ps1`** to set the SQL instance name and sa password
 
 - Apply overrides
-  ```
-	.\set-installation-overrides.ps1
-	```
+
+    ```powershell
+    .\set-installation-overrides.ps1
+    ```
 
 > **KNOWN ISSUE:** Automatic download of assets is current not working as expected.
 > 
@@ -32,17 +36,24 @@ Still in an elevated PowerShell session
 > - [Sitecore.Commerce.2018.07-2.2.126.zip](https://dev.sitecore.net/~/media/F374366CA5C649C99B09D35D5EF1BFCE.ashx) - `xc/install/assets/downloads`
 > - [Habitat Home Product Images.zip](https://sitecore.box.com/shared/static/bjvge68eqge87su5vg258366rve6bg5d.zip) - `xc/install/assets/Commerce`
 
-Once the above files have been downloaded:
+Once the above files have been downloaded, these are **_2 options_** to install the Sitecore Experience Commerce
 
-```
-install-xc0.ps1
-```
+- If you plan to install the **Sitecore.HabitatHome.Commerce** later, just execute the script (without parameter)
+
+    ```powershell
+    .\install-xc0.ps1
+    ```
+- Otherwise, you plan to install the fresh Sitecore Experience Commerce without **HabitatAuthoring** has been bootstrapped. Just simply append `-SkipInstallHabitatAuthoring` as below
+  
+    ```powershell
+    .\install-xc0.ps1 -SkipInstallHabitatAuthoring
+    ```
 
 ## Troubleshooting
 
 #### Resuming Installation
 
-If a part of the installation fails, you can resume from the last failed step by removing the relevant tasks in the Commerce_SingleServer.json file.
+If a part of the installation fails, you can resume from the last failed step by removing the relevant tasks in the `Commerce_SingleServer.json` file.
 
 The file is located in `XC\install\assets\Resources`.
 

--- a/XC/install/README.md
+++ b/XC/install/README.md
@@ -38,15 +38,15 @@ Still in an elevated PowerShell session
 
 Once the above files have been downloaded, these are **_2 options_** to install the Sitecore Experience Commerce
 
-- If you plan to install the **Sitecore.HabitatHome.Commerce** later, just execute the script (without parameter)
+- If you plan on installing Habitat Home Demo (**Sitecore.HabitatHome.Commerce**), execute the script without parameter
 
     ```powershell
     .\install-xc0.ps1
     ```
-- Otherwise, you plan to install the fresh Sitecore Experience Commerce without **HabitatAuthoring** has been bootstrapped. Just simply append `-SkipInstallHabitatAuthoring` as below
+- If you simply want a fresh instance of Sitecore Experience Commerce without the pre-loaded demo assets, simply append `-SkipHabitatHomeInstall` as below
   
     ```powershell
-    .\install-xc0.ps1 -SkipInstallHabitatAuthoring
+    .\install-xc0.ps1 -SkipHabitatHomeInstall
     ```
 
 ## Troubleshooting

--- a/XC/install/Set-CommerceEngineHostName.ps1
+++ b/XC/install/Set-CommerceEngineHostName.ps1
@@ -29,7 +29,7 @@ if (!$config) {
 #    Import-Module Carbon
 #}
 
-$engineSites = @("CommerceAuthoring_{0}:5000", "CommerceMinions_{0}:5010", "CommerceOps_{0}:5015", "CommerceShops_{0}:5005", "SitecoreBizFx:4200", "SitecoreIdentityServer:5050")
+$engineSites = @("CommerceAuthoring_{0}:5000", "CommerceMinions_{0}:5010", "CommerceOps_{0}:5015", "CommerceShops_{0}:5005", "SitecoreBizFx_{0}:4200", "SitecoreIdentityServer_{0}:5050")
 
 $site = $config.settings.site
 $assets = $config.assets

--- a/XC/install/assets/Resources/Configuration/Commerce/SitecoreIdentityServer/SitecoreIdentityServer.json
+++ b/XC/install/assets/Resources/Configuration/Commerce/SitecoreIdentityServer/SitecoreIdentityServer.json
@@ -38,7 +38,7 @@
     "SitecoreIdentityServerPhysicalPath": "[joinpath(parameter('WebRoot'), parameter('SitecoreIdentityServerName'))]",
     "Root.Cert.DnsName": "[concat('DO_NOT_TRUST_', parameter('RootCertFileName'))]",
     "Root.Cert.Store": "cert:\\LocalMachine\\Root",
-    "Security.CertificateName": "identity.server",
+    "Security.CertificateName": "[parameter('SitecoreIdentityServerName')]",
     "Security.CertificateStore": "cert:\\Localmachine\\My",
     "Security.CertificateThumbprint": "[GetCertificateThumbprint(variable('Security.CertificateName'), variable('Security.CertificateStore'))]",
     "Security.CertificatePath": "[joinpath(variable('Security.CertificateStore'), variable('Security.CertificateThumbprint'))]"
@@ -131,7 +131,7 @@
         "CertificateDnsName": "[variable('Security.CertificateName')]",
         "CertificatePassword": "sitecore",
         "CertificateStore": "[variable('Security.CertificateStore')]",
-        "CertificateFriendlyName": "Sitecore Identity Server",
+        "CertificateFriendlyName": "[parameter('SitecoreIdentityServerName')]",
         "IDServerPath": "[variable('SitecoreIdentityServerPhysicalPath')]"
       }
     },

--- a/XC/install/install-xc0.ps1
+++ b/XC/install/install-xc0.ps1
@@ -1,6 +1,6 @@
 Param(
     [string] $ConfigurationFile = '.\configuration-xc0.json',
-    [switch] $Blank
+    [switch] $SkipInstallHabitatAuthoring
 )
 
 #####################################################
@@ -348,7 +348,7 @@ Function Install-Commerce {
         }
         SitecoreIdentityServerName                  = $commerce.identityServerName
     }
-    If (!$Blank){
+    If (!$SkipInstallHabitatAuthoring){
         Install-SitecoreConfiguration @params -WorkingDirectory $(Join-Path $PWD "logs")
     } Else {
         Install-SitecoreConfiguration @params -Skip "InitializeCommerceEngine","GenerateCatalogTemplates","InstallHabitatImagesModule","Reindex" -WorkingDirectory $(Join-Path $PWD "logs")

--- a/XC/install/install-xc0.ps1
+++ b/XC/install/install-xc0.ps1
@@ -1,6 +1,6 @@
 Param(
     [string] $ConfigurationFile = '.\configuration-xc0.json',
-    [switch] $SkipInstallHabitatAuthoring
+    [switch] $SkipHabitatHomeInstall
 )
 
 #####################################################
@@ -348,7 +348,7 @@ Function Install-Commerce {
         }
         SitecoreIdentityServerName                  = $commerce.identityServerName
     }
-    If (!$SkipInstallHabitatAuthoring){
+    If (!$SkipHabitatHomeInstall){
         Install-SitecoreConfiguration @params -WorkingDirectory $(Join-Path $PWD "logs")
     } Else {
         Install-SitecoreConfiguration @params -Skip "InitializeCommerceEngine","GenerateCatalogTemplates","InstallHabitatImagesModule","Reindex" -WorkingDirectory $(Join-Path $PWD "logs")

--- a/XC/install/install-xc0.ps1
+++ b/XC/install/install-xc0.ps1
@@ -1,5 +1,6 @@
 Param(
-    [string] $ConfigurationFile = '.\configuration-xc0.json'
+    [string] $ConfigurationFile = '.\configuration-xc0.json',
+    [switch] $Blank
 )
 
 #####################################################
@@ -347,8 +348,11 @@ Function Install-Commerce {
         }
         SitecoreIdentityServerName                  = $commerce.identityServerName
     }
-
-    Install-SitecoreConfiguration @params -WorkingDirectory $(Join-Path $PWD "logs")
+    If (!$Blank){
+        Install-SitecoreConfiguration @params -WorkingDirectory $(Join-Path $PWD "logs")
+    } Else {
+        Install-SitecoreConfiguration @params -Skip "InitializeCommerceEngine","GenerateCatalogTemplates","InstallHabitatImagesModule","Reindex" -WorkingDirectory $(Join-Path $PWD "logs")
+    }
 }
 
 


### PR DESCRIPTION
The changes aims to support to install more than one Sitecore Commerce instance, it's also added the ability to install the fresh Sitecore Commerce instance as well.

`Add-BindingsToCommerceSites.ps1` & 
- Correct the name of SitecoreBizFx and SitecoreIdentityServer by adding the suffix (i.e. habitathome)
- Correct the port of CommerceShops engine site which is **5005**

`Set-CommerceEngineHostName.ps1`
- Correct the name of SitecoreBizFx and SitecoreIdentityServer by adding the suffix (i.e. habitathome)

`SitecoreIdentityServer.json`
- Specify the certificate's name of SitecoreIdentityServer by using exactly the site name (i.e. SitecoreIdentityServer_habitathome) instead **identity.server** as origin. Since each Sitecore Commerce instance need its own IdentityServer 

`install-xc0.ps1`
- Adding the `$Blank` parameter in order to recognize the installation for fresh Sitecore Commerce instance (without HabitatAuthoring environment, hence developers are able to start their engine later)