### PR TITLE
Habitat Home Installation improvements

### DIFF
--- a/Azure/CreateNewSnapshot.ps1
+++ b/Azure/CreateNewSnapshot.ps1
@@ -1,5 +1,7 @@
 Param(
+    [Parameter(Mandatory = $true)]
     [string] $subscriptionId,
+    [Parameter(Mandatory = $true)]
     [ValidateSet('xp', 'xc')]
     [string] $demoType,
 	[Parameter(Mandatory = $true)]
@@ -11,6 +13,7 @@ Param(
     [string] $snapshotDestinationResourceGroup = "habitathome-demo-snapshot"
 
 )
+Import-Module AzureRM
 $account = Get-AzureRMContext | Select-Object Account
 
 if ($null -eq $account.Account) {

--- a/XP/install/assets.json
+++ b/XP/install/assets.json
@@ -1,15 +1,17 @@
 {
-
-    "sitecore": [{
-        "id": "xp",
-        "name": "Sitecore Experience Platform",
-        "fileName": "Sitecore 9.1.0 rev. 001564 (WDP XPSingle packages).zip",
-        "url": "https://dev.sitecore.net/~/media/442BA3B6E6334CEA9546C647D434BC13.ashx",
-        "extract": true,
-        "download": true,
-        "source": "sitecore"
-    }],
-    "modules": [{
+    "sitecore": [
+        {
+            "id": "xp",
+            "name": "Sitecore Experience Platform",
+            "fileName": "Sitecore 9.1.0 rev. 001564 (WDP XPSingle packages).zip",
+            "url": "https://dev.sitecore.net/~/media/442BA3B6E6334CEA9546C647D434BC13.ashx",
+            "extract": true,
+            "download": true,
+            "source": "sitecore"
+        }
+    ],
+    "modules": [
+        {
             "id": "sat",
             "name": "Sitecore Azure Toolkit",
             "fileName": "Sitecore Azure Toolkit 2.1.0 rev. 181023.zip",
@@ -45,7 +47,8 @@
             "isGroup": true,
             "download": false,
             "install": false,
-            "modules": [{
+            "modules": [
+                {
                     "id": "def",
                     "name": "Data Exchange Framework",
                     "fileName": "Data Exchange Framework 2.0.1 rev. 180108.zip",
@@ -91,7 +94,8 @@
                     "isGroup": true,
                     "download": false,
                     "install": false,
-                    "modules": [{
+                    "modules": [
+                        {
                             "id": "defDynamics",
                             "name": "Dynamics Provider Data Exchange Framework",
                             "fileName": "Dynamics Provider for Data Exchange Framework 2.0.1 rev. 180108.zip",
@@ -119,7 +123,8 @@
                     "isGroup": true,
                     "download": false,
                     "install": false,
-                    "modules": [{
+                    "modules": [
+                        {
                             "id": "defSalesforce",
                             "name": "Salesforce CRM Provider for Data Exchange Framework",
                             "fileName": "Salesforce Provider for Data Exchange Framework 2.0.1 rev. 180108.zip",
@@ -141,7 +146,6 @@
                         }
                     ]
                 }
-
             ]
         },
         {
@@ -175,26 +179,34 @@
             "source": "external"
         }
     ],
-    "habitatHome": [{
-            "id": "habitathome",
-            "name": "Habitat Home",
-            "fileName": "HabitatHome_single.scwdp.zip",
-            "url": "https://github.com/Sitecore/Sitecore.HabitatHome.Platform/releases/download/9.1.0.0-beta1/HabitatHome_single.scwdp.zip",
-            "download": true,
-            "install": true,
-            "convert": false,
-            "source": "external"
-        },
-        {
-            "id": "habitathome_xConnect",
-            "name": "Habitat Home xConnect",
-            "fileName": "xConnect_single.scwdp.zip",
-            "url": "https://github.com/Sitecore/Sitecore.HabitatHome.Platform/releases/download/9.1.0.0-beta1/xConnect_single.scwdp.zip",
-            "download": true,
-            "install": true,
-            "convert": false,
-            "source": "external"
-        }
-    ]
-
+    "habitatHome": {
+        "id": "habitatHome",
+        "isGroup": true,
+        "download": true,
+        "install": true,
+        "version": "9.1.0.0",
+        "prerelease": true,
+        "modules": [
+            {
+                "id": "habitathome",
+                "name": "Habitat Home",
+                "fileName": "HabitatHome_single.scwdp.zip",
+                "url": "https://github.com/Sitecore/Sitecore.HabitatHome.Platform/releases/download/{version}/HabitatHome_single.scwdp.zip",
+                "download": true,
+                "install": true,
+                "convert": false,
+                "source": "external"
+            },
+            {
+                "id": "habitathome_xConnect",
+                "name": "Habitat Home xConnect",
+                "fileName": "xConnect_single.scwdp.zip",
+                "url": "https://github.com/Sitecore/Sitecore.HabitatHome.Platform/releases/download/{version}/xConnect_single.scwdp.zip",
+                "download": true,
+                "install": true,
+                "convert": false,
+                "source": "external"
+            }
+        ]
+    }
 }

--- a/XP/install/assets/configuration/HabitatHome/habitathome.json
+++ b/XP/install/assets/configuration/HabitatHome/habitathome.json
@@ -58,7 +58,7 @@
       "DefaultValue": "Off",
       "Description": "Turn Unicorn functionality on or off"
     },
-    "3rdPartyIntegrations": {
+    "ThirdPartyIntegrations": {
       "Type": "string",
       "DefaultValue": "None",
       "Description": "Use a keyword like CDN, Dynamics, Salesforce, Facebook, MS to enable. See README for details."
@@ -160,7 +160,7 @@
             },
             {
               "Name": "3rd Party Integrations",
-              "Value":"[parameter('3rdPartyIntegrations')]"
+              "Value":"[parameter('ThirdPartyIntegrations')]"
             },
             {
               "Name": "ASP.NET Debugging",

--- a/XP/install/install-habitathome.ps1
+++ b/XP/install/install-habitathome.ps1
@@ -41,7 +41,7 @@ $site = $config.settings.site
 $sql = $config.settings.sql
 $xConnect = $config.settings.xConnect
 $resourcePath = Join-Path $assets.root "configuration"
-
+$habitatHomeSettings = $config.settings.habitatHome
 $downloadJsonPath = $([io.path]::combine($resourcePath, 'HabitatHome', 'download-assets.json'))
 $downloadFolder = $assets.root
 $packagesFolder = (Join-Path $downloadFolder "packages")
@@ -114,7 +114,7 @@ Function Get-HabitatHome {
   
     # Download modules
     $args = @{
-        Packages         = $downloadAssets
+        Packages         = $downloadAssets.modules
         PackagesFolder   = $packagesFolder
         DownloadJsonPath = $downloadJsonPath
     }
@@ -135,7 +135,9 @@ Function Get-Packages {
         if ($true -eq $package.download) {
             Write-Host ("Downloading {0}  -  if required" -f $package.name )
             $destination = $package.fileName
-            if (!(Test-Path $destination)) {
+            if ((Test-Path $destination)) {
+                Remove-Item $destination # Ensure we always have the latest.
+            }
                 $user = ""# $credentials.GetNetworkCredential().UserName
                 $password = ""# $Credentials.GetNetworkCredential().Password
 
@@ -150,7 +152,7 @@ Function Get-Packages {
                 $Global:ProgressPreference = 'SilentlyContinue'
                 Install-SitecoreConfiguration  @params -WorkingDirectory $(Join-Path $PWD "logs")  
                 $Global:ProgressPreference = 'Continue'
-            }
+            
         }
     }
 }
@@ -232,26 +234,42 @@ Function Install-Bootloader{
 
 Function Install-HabitatHome {
 
-    $hh = $habitatHome | Where-Object { $_.id -eq "habitathome"}
+    $hh = $habitatHome.modules | Where-Object { $_.id -eq "habitathome"} 
     if ($false -eq $hh.install) {
         return
     }
     
     $params = @{
-        Path             = (Join-path $resourcePath 'HabitatHome\habitathome.json')
-        Package          = $hh.fileName
-        SiteName         = $site.hostName
-        SqlDbPrefix      = $site.prefix 
-        SqlAdminUser     = $sql.adminUser 
-        SqlAdminPassword = $sql.adminPassword 
-        SqlServer        = $sql.server 
+        Path                                = (Join-path $resourcePath 'HabitatHome\habitathome.json')
+        Package                             = $hh.fileName
+        SiteName                            = $site.hostName
+        SqlDbPrefix                         = $site.prefix 
+        SqlAdminUser                        = $sql.adminUser 
+        SqlAdminPassword                    = $sql.adminPassword 
+        SqlServer                           = $sql.server
+        DemoDynamicsCRMConnectionString     = ($habitatHomeSettings | Where-Object {$_.id -eq "Demo Dynamics CRM Connection String"}).value
+        DemoCRMSalesForceConnectionString   = ($habitatHomeSettings | Where-Object {$_.id -eq "DemoCRMSalesForceConnectionString"}).value
+        EnableEXMmodule                     = ($habitatHomeSettings | Where-Object {$_.id -eq "EnableEXMmodule"}).value
+        AllowInvalidSSLCertificate          = ($habitatHomeSettings | Where-Object {$_.id -eq "AllowInvalidSSLCertificate"}).value
+        EnvironmentType                     = ($habitatHomeSettings | Where-Object {$_.id -eq "EnvironmentType"}).value
+        UnicornEnabled                      = ($habitatHomeSettings | Where-Object {$_.id -eq "UnicornEnabled"}).value
+        ThirdPartyIntegrations              = ($habitatHomeSettings | Where-Object {$_.id -eq "ThirdPartyIntegrations"}).value
+        ASPNETDebugging                     = ($habitatHomeSettings | Where-Object {$_.id -eq "ASPNETDebugging"}).value
+        CDNEnabled                          = ($habitatHomeSettings | Where-Object {$_.id -eq "CDNEnabled"}).value
+        MediaAlwaysIncludeServerURL         = ($habitatHomeSettings | Where-Object {$_.id -eq "MediaAlwaysIncludeServerURL"}).value
+        MediaLinkServerURL                  = ($habitatHomeSettings | Where-Object {$_.id -eq "MediaLinkServerURL"}).value
+        MediaResponseCacheabilityType       = ($habitatHomeSettings | Where-Object {$_.id -eq "MediaResponseCacheabilityType"}).value
+        DemoEnabled                         = ($habitatHomeSettings | Where-Object {$_.id -eq "DemoEnabled"}).value
+        RootHostName                        = ($habitatHomeSettings | Where-Object {$_.id -eq "RootHostName"}).value
+        AnalyticsCookieDomain               = ($habitatHomeSettings | Where-Object {$_.id -eq "AnalyticsCookieDomain"}).value
+  
     }
     
     Install-SitecoreConfiguration @params -WorkingDirectory $(Join-Path $PWD "logs") 
 }
 Function Install-HabitatHomeXConnect {
 
-    $xc = $habitatHome | Where-Object { $_.id -eq "habitathome_xConnect"}
+    $xc = $habitatHome.modules | Where-Object { $_.id -eq "habitathome_xConnect"}
     if ($false -eq $xc.install) {
         return
     }

--- a/XP/install/install-habitathome.ps1
+++ b/XP/install/install-habitathome.ps1
@@ -247,7 +247,7 @@ Function Install-HabitatHome {
         SqlAdminUser                        = $sql.adminUser 
         SqlAdminPassword                    = $sql.adminPassword 
         SqlServer                           = $sql.server
-        DemoDynamicsCRMConnectionString     = ($habitatHomeSettings | Where-Object {$_.id -eq "Demo Dynamics CRM Connection String"}).value
+        DemoDynamicsCRMConnectionString     = ($habitatHomeSettings | Where-Object {$_.id -eq "DemoDynamicsCRMConnectionString"}).value
         DemoCRMSalesForceConnectionString   = ($habitatHomeSettings | Where-Object {$_.id -eq "DemoCRMSalesForceConnectionString"}).value
         EnableEXMmodule                     = ($habitatHomeSettings | Where-Object {$_.id -eq "EnableEXMmodule"}).value
         AllowInvalidSSLCertificate          = ($habitatHomeSettings | Where-Object {$_.id -eq "AllowInvalidSSLCertificate"}).value

--- a/XP/install/install-modules.ps1
+++ b/XP/install/install-modules.ps1
@@ -132,8 +132,8 @@ Function Process-Packages {
         $DownloadJsonPath
     )
     foreach ($package in $Packages) {
-        if ($package.id -eq "xp" -or $package.id -eq "sat" -or $package.id -eq "si") {
-            # Skip Sitecore Azure Toolkit and XP package and Sitecore identity - previously downloaded
+        if ($package.id -eq "xp" -or $package.id -eq "sat" -or $package.id -eq "si" -or $package.id -eq "habitatHome") {
+            # Skip Sitecore Azure Toolkit and XP package and Sitecore identity - downloaded separately
             continue;
         }
 

--- a/XP/install/install-settings.json
+++ b/XP/install/install-settings.json
@@ -87,77 +87,77 @@
     },
     "habitatHome": [
       {
-        "id": "Demo Dynamics CRM Connection String",
+        "id": "DemoDynamicsCRMConnectionString",
         "value": "",
         "description": "Connection string for Dynamics CRM"
       },
       {
-        "id": "Demo CRM SalesForce Connection String",
+        "id": "DemoCRMSalesForceConnectionString",
         "value": "",
         "description": "Connection string for SalesForce CRM connector"
       },
       {
-        "id": "Enable EXM module",
+        "id": "EnableEXMmodule",
         "value": "yes",
         "description": "Enable or disable the EXM module. Values: 'yes' or 'no'"
       },
       {
-        "id": "Allow Invalid SSL Certificate",
-        "value": "True",
+        "id": "AllowInvalidSSLCertificate",
+        "value": true,
         "description": "Allows the use of self-signed certificates for communication with XConnect. Values: 'True' or 'False'"
       },
       {
-        "id": "Environment Type",
+        "id": "EnvironmentType",
         "value": "Local",
         "description": "Define the environment (Local or Production) - this affect some configuration settings"
       },
       {
-        "id": "Unicorn On/Off",
+        "id": "UnicornEnabled",
         "value": "Off",
         "description": "Turn Unicorn functionality on or off"
       },
       {
-        "id": "3rd Party Integrations",
+        "id": "ThirdPartyIntegrations",
         "value": "None",
         "description": "Use a keyword like CDN, Dynamics, Salesforce, Facebook, MS to enable"
       },
       {
-        "id": "ASP.NET Debugging",
-        "value": "false",
+        "id": "ASPNETDebugging",
+        "value": false,
         "description": "Turn debugging on or off for the environment. Values: 'true' or 'false'"
       },
       {
-        "id": "CDN Enabled",
-        "value": "False",
+        "id": "CDNEnabled",
+        "value": false,
         "description": "Enable or disable CDN. Values: 'True' or 'False'"
       },
       {
-        "id": "Media/Always Include Server URL",
-        "value": "False",
+        "id": "MediaAlwaysIncludeServerURL",
+        "value": false,
         "description": "Enable or disable Media URL display behavior. Values: 'True' or 'False'"
       },
       {
-        "id": "Media/Link Server URL",
+        "id": "MediaLinkServerURL",
         "value": "",
         "description": "URL to the media server (if any)"
       },
       {
-        "id": "Media Response/Cacheability type",
+        "id": "MediaResponseCacheabilityType",
         "value": "private",
         "description": "The type of cacheability of the media files on remote or proxy servers - private or public"
       },
       {
-        "id": "Demo Enabled",
-        "value": "True",
+        "id": "DemoEnabled",
+        "value": true,
         "description": "Enable or disable the demo mode. Values: 'True' or 'False'"
       },
       {
-        "id": "Root Host Name",
+        "id": "RootHostName",
         "value": "",
         "description": "Habitat hostname"
       },
       {
-        "id": "Analytics Cookie Domain",
+        "id": "AnalyticsCookieDomain",
         "value": "",
         "description": "Analytics cookie domain name"
       }

--- a/XP/install/install-singledeveloper.ps1
+++ b/XP/install/install-singledeveloper.ps1
@@ -233,7 +233,7 @@ Function Install-SingleDeveloper {
         SitecoreIdentityAuthority       = "https://" + $identityServer.name
         XConnectCollectionService       = "https://" + $xConnect.siteName
         ClientSecret                    = $identityServer.clientSecret
-        AllowedCorsOrigins              = "https://" + $site.hostName
+        AllowedCorsOrigins              = ("https://{0}|https://{1}" -f  $site.hostName, "habitathomebasic.dev.local") # Need to add to proper config
         WebRoot                         = $site.webRoot
     }
 


### PR DESCRIPTION
- Refactored the way the Habitat Home package was stored in assets.json 
- Added a condition to skip download of HabitatHome in install-modules
- Renamed all WDP settings to be 'standard' / no spaces
- Refactored SIF template for HabitatHome
- Added habitathomebasic url to AllowedCorsOrigin for IdentityServer
  - Need to change that so that it's not hardcoded in the future
- dynamically download latest Habitat Home release assets from GitHub
- CeateNewSnapshot.ps1
  - Tagged some parameters as Mandator
  - Added call to Import-Module