### PR TITLE
removed duplicated task in Sitecore-XP0

### DIFF
--- a/XP/install/Sitecore.WDP.Resources/content/Deployment/OnPrem/Platform/XP0/sitecore-XP0.json
+++ b/XP/install/Sitecore.WDP.Resources/content/Deployment/OnPrem/Platform/XP0/sitecore-XP0.json
@@ -298,13 +298,6 @@
                 "HostName": "[parameter('SiteName')]"
             }
         },
-        "CreateBindingsWithDevelopmentThumprint": {
-            "Type": "AddWebFeatureSSL",
-            "Params": {
-                "HostName": "[parameter('SiteName')]",
-                "OutputDirectory": "[variable('Site.DataFolder')]"
-            }
-        },
         "SetPermissions": {
             "Type": "FilePermissions",
             "Params": {


### PR DESCRIPTION
Fix issue related to install Sitecore XP 9.0.2:
Error detail:
TerminatingError(Add-WebFeatureSSL): "Cannot validate argument on parameter 'OutputDirectory'. The " Test-Path $_ -Type Container " validation script for the argument with value "C:\inetpub\wwwroot\habitathome.dev.local\App_Data" did not return a result of True. Determine why the validation script failed, and then try the command again."
Install-SitecoreConfiguration : Cannot validate argument on parameter 'OutputDirectory'. The " Test-Path $_ -Type 
Container " validation script for the argument with value "C:\inetpub\wwwroot\habitathome.dev.local\App_Data" did not 
return a result of True. Determine why the validation script failed, and then try the command again.
At C:\Projects\Sitecore.HabitatHome.Utilities\XP\install\install-xp0.ps1:349 char:9