### PR TITLE
Feature/improve populate sxa

### DIFF
--- a/XP/install/assets/configuration/HabitatHome/sxa-solr.json
+++ b/XP/install/assets/configuration/HabitatHome/sxa-solr.json
@@ -175,7 +175,7 @@
       "Type": "SitecoreUrl",
       "Params": {
         "SitecoreInstanceRoot": "[concat('https://', parameter('SiteName'))]",
-        "SitecoreActionPath": "sitecore/admin/PopulateManagedSchema.aspx?indexes=all",
+        "SitecoreActionPath": "[concat('sitecore/admin/PopulateManagedSchema.aspx?indexes=',variable('SXA.Master.Name'),'|',variable('SXA.Web.Name'))]",
         "UserName": "admin",
         "Password": "[parameter('SitecoreAdminPassword')]"
       }


### PR DESCRIPTION
Changed PopulateManagedSchema to only pass in SXA core names rather than 'all'