### PR TITLE
Fixed missing xConnect models: install-habitathome.ps1

### DIFF
--- a/XP/install/assets/configuration/HabitatHome/xconnect-models.json
+++ b/XP/install/assets/configuration/HabitatHome/xconnect-models.json
@@ -1,0 +1,44 @@
+{
+    "Parameters": {
+        "WebRoot": {
+            "Type": "string",
+            "DefaultValue": "XConnect",
+            "Description": "The name of the site to be deployed."
+        },
+        "SiteName": {
+            "Type": "string",
+            "DefaultValue": "SC9",
+            "Description": "The name of the site to be deployed."
+        },
+        "XConnectSiteName": {
+            "Type": "string",
+            "DefaultValue": "XConnect",
+            "Description": "The name of the site to be deployed."
+        },
+        "ModelName": {
+            "Type": "string",
+            "Description": "List of deta"
+        },
+        "Target": {
+            "Type": "string",
+            "DefaultValue": "App_Data\\Models",
+            "Description": "Destination where model should be deployed"
+        }
+    },
+    "Variables": {
+        "Site.PhysicalPath": "[joinpath(parameter('WebRoot'), parameter('SiteName'))]",
+        "Site.ModelsPath": "[joinpath(variable('Site.PhysicalPath'), 'App_Data\\Models')]",
+        "ModelPath": "[joinpath(variable('Site.ModelsPath'), parameter('ModelName'))]",
+        "XConnect.PhysicalPath":"[joinpath(parameter('WebRoot'), parameter('XConnectSiteName'))]",
+        "Destination": "[joinpath(variable('XConnect.PhysicalPath'), parameter('Target'))]"
+    },
+    "Tasks": {
+        "CopyModel": {
+            "Type": "Copy",
+            "Params": {
+                "Source": "[variable('ModelPath')]",
+                "Destination": "[variable('Destination')]"
+            }
+        }
+    }
+}

--- a/XP/install/install-habitathome.ps1
+++ b/XP/install/install-habitathome.ps1
@@ -292,8 +292,29 @@ Function Install-HabitatHomeXConnect {
     }
      
     Install-SitecoreConfiguration @params -WorkingDirectory $(Join-Path $PWD "logs") 
+   
+   
 }
 
+Function Deploy-XConnectModels {
+    $modelDestinations = @("App_Data\Models", "App_Data\jobs\continuous\IndexWorker\App_data\Models")
+    $models = Get-ChildItem $([io.path]::combine($site.webRoot, $site.hostName, "App_Data\Models"))
+
+    foreach ($model in $models) {
+
+        foreach ($destination in $modelDestinations) {
+            $deployModelParams = @{
+                Path             = (Join-path $resourcePath 'HabitatHome\xconnect-models.json')
+                WebRoot          = $site.webRoot
+                SiteName         = $site.hostName
+                XConnectSiteName = $xConnect.siteName
+                ModelName        = $model.name
+                Target           = $destination
+            }
+            Install-SitecoreConfiguration @deployModelParams -WorkingDirectory $(Join-Path $PWD "logs") 
+        }
+    }
+}
 Function Enable-ContainedDatabases {
     #Enable Contained Databases
     Write-Host "Enable contained databases" -ForegroundColor Green
@@ -368,6 +389,7 @@ Stop-Services
 Install-Bootloader
 Install-HabitatHome
 Install-HabitatHomeXConnect
+Deploy-XConnectModels
 Enable-ContainedDatabases
 Add-DatabaseUsers
 Start-Services


### PR DESCRIPTION
Added 'Deploy-XConnectModels' which copies the site's App_Data\Models… contents to the relevant xConnect destinations