### PR TITLE
Fix - Error for internal nugetserver that can't be reached, refactore…

### DIFF
--- a/Prerequisites/Install-SitecoreGallery.ps1
+++ b/Prerequisites/Install-SitecoreGallery.ps1
@@ -1,14 +1,14 @@
 param (
-    [string]$nugetServer="http://nuget1ca2/nuget/Sitecore_Gallery"
+    [string]$mygetServer = "https://sitecore.myget.org/F/sc-powershell/api/v2"
 )
 
 $gallery = Get-PSRepository|Where-Object {$_.Name -eq "SitecoreGallery"} 
 
 if (!$gallery) {
-    Register-PSRepository -Name SitecoreGallery -SourceLocation $nugetServer -PublishLocation $nugetServer -InstallationPolicy Trusted
+    Register-PSRepository -Name SitecoreGallery -SourceLocation $mygetServer -PublishLocation $mygetServer -InstallationPolicy Trusted
 }
-elseif (($gallery.SourceLocation -ne $nugetServer) -or ($gallery.PublishLocation -ne $nugetServer) -or !$gallery.Trusted) {
-    Set-PSRepository -Name SitecoreGallery -SourceLocation $nugetServer -PublishLocation $nugetServer -InstallationPolicy Trusted
+elseif (($gallery.SourceLocation -ne $mygetServer) -or ($gallery.PublishLocation -ne $mygetServer) -or !$gallery.Trusted) {
+    Set-PSRepository -Name SitecoreGallery -SourceLocation $mygetServer -PublishLocation $mygetServer -InstallationPolicy Trusted
 }
 
 Get-PSRepository -Name "SitecoreGallery" | Format-List * -Force


### PR DESCRIPTION
…d to make use of myget server

=========================[START].\Install-SitecoreGallery.ps1=============================
Set-PSRepository : The specified Uri 'http://nuget1ca2/nuget/Sitecore_Gallery' for parameter 'SourceLocation' is an
invalid Web Uri. Please ensure that it meets the Web Uri requirements.
At C:\Projects\Sitecore.HabitatHome.Utilities\Prerequisites\Install-SitecoreGallery.ps1:11 char:5
+     Set-PSRepository -Name SitecoreGallery -SourceLocation $nugetServ ...
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (http://nuget1ca2/nuget/Sitecore_Gallery:String) [Set-PSRepository], Ar
   gumentException
    + FullyQualifiedErrorId : InvalidWebUri,Set-PSRepository