### PR TITLE
Fix for README.MD linking, needs to be lowercase i instead of uppercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ See the [README.md](Warmup/README.md) in the Warmup folder for a detailed descri
 
 The XC folder contains a set of scripts for installing Sitecore Experience Commerce 9 with all the required modules.
 
-See the [README.md](XC/Install/README.md) in the XC/install folder for a detailed description and instructions.
+See the [README.md](XC/install/README.md) in the XC/install folder for a detailed description and instructions.
 
 #### XP
 
 The XP folder contains a set of scripts for installing Sitecore Experience Platform 9 with all the required modules and certificates.
 
-See the [README.md](XP/Install/README.md) in the XP/install folder for a detailed description and instructions.
+See the [README.md](XP/install/README.md) in the XP/install folder for a detailed description and instructions.


### PR DESCRIPTION
Fix for README.MD linking, needs to be lowercase i , instead of uppercase I (of install, not Install), apparently is case sensitive

https://github.com/Sitecore/Sitecore.HabitatHome.Utilities/blob/develop/XC/Install/README.md -> incorrect, throws a 404
https://github.com/Sitecore/Sitecore.HabitatHome.Utilities/blob/develop/XC/install/README.md -> correct, links correctly.

Adjusted links to XC install readme file and adjusted links to XP install readme file